### PR TITLE
Use get() instead of value() on optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # version of CMake by first installing Extra Packages for Enterprise Linux
 # (https://fedoraproject.org/wiki/EPEL#Extra_Packages_for_Enterprise_Linux_.28EPEL.29)
 # and then issuing `yum install cmake3` on the command line.
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.0)
 
 project(SimpleAmqpClient LANGUAGES CXX)
 

--- a/src/BasicMessage.cpp
+++ b/src/BasicMessage.cpp
@@ -74,7 +74,7 @@ void BasicMessage::Body(const std::string& body) { m_impl->body = body; }
 
 const std::string& BasicMessage::ContentType() const {
   if (ContentTypeIsSet()) {
-    return m_impl->content_type.value();
+    return m_impl->content_type.get();
   }
   static const std::string empty;
   return empty;
@@ -92,7 +92,7 @@ void BasicMessage::ContentTypeClear() { m_impl->content_type.reset(); }
 
 const std::string& BasicMessage::ContentEncoding() const {
   if (ContentEncodingIsSet()) {
-    return m_impl->content_encoding.value();
+    return m_impl->content_encoding.get();
   }
   static const std::string empty;
   return empty;
@@ -109,7 +109,7 @@ bool BasicMessage::ContentEncodingIsSet() const {
 void BasicMessage::ContentEncodingClear() { m_impl->content_encoding.reset(); }
 
 BasicMessage::delivery_mode_t BasicMessage::DeliveryMode() const {
-  return m_impl->delivery_mode.value_or(dm_notset);
+  return m_impl->delivery_mode.get_value_or(dm_notset);
 }
 
 void BasicMessage::DeliveryMode(delivery_mode_t delivery_mode) {
@@ -123,7 +123,7 @@ bool BasicMessage::DeliveryModeIsSet() const {
 void BasicMessage::DeliveryModeClear() { m_impl->delivery_mode.reset(); }
 
 boost::uint8_t BasicMessage::Priority() const {
-  return m_impl->priority.value_or(0);
+  return m_impl->priority.get_value_or(0);
 }
 
 void BasicMessage::Priority(boost::uint8_t priority) {
@@ -138,7 +138,7 @@ void BasicMessage::PriorityClear() { m_impl->priority.reset(); }
 
 const std::string& BasicMessage::CorrelationId() const {
   if (CorrelationIdIsSet()) {
-    return m_impl->correlation_id.value();
+    return m_impl->correlation_id.get();
   }
   static const std::string empty;
   return empty;
@@ -156,7 +156,7 @@ void BasicMessage::CorrelationIdClear() { m_impl->correlation_id.reset(); }
 
 const std::string& BasicMessage::ReplyTo() const {
   if (ReplyToIsSet()) {
-    return m_impl->reply_to.value();
+    return m_impl->reply_to.get();
   }
   static const std::string empty;
   return empty;
@@ -174,7 +174,7 @@ void BasicMessage::ReplyToClear() { m_impl->reply_to.reset(); }
 
 const std::string& BasicMessage::Expiration() const {
   if (ExpirationIsSet()) {
-    return m_impl->expiration.value();
+    return m_impl->expiration.get();
   }
   static const std::string empty;
   return empty;
@@ -192,7 +192,7 @@ void BasicMessage::ExpirationClear() { m_impl->expiration.reset(); }
 
 const std::string& BasicMessage::MessageId() const {
   if (MessageIdIsSet()) {
-    return m_impl->message_id.value();
+    return m_impl->message_id.get();
   }
   static const std::string empty;
   return empty;
@@ -209,7 +209,7 @@ bool BasicMessage::MessageIdIsSet() const {
 void BasicMessage::MessageIdClear() { m_impl->message_id.reset(); }
 
 boost::uint64_t BasicMessage::Timestamp() const {
-  return m_impl->timestamp.value_or(0);
+  return m_impl->timestamp.get_value_or(0);
 }
 void BasicMessage::Timestamp(boost::uint64_t timestamp) {
   m_impl->timestamp = timestamp;
@@ -223,7 +223,7 @@ void BasicMessage::TimestampClear() { m_impl->timestamp.reset(); }
 
 const std::string& BasicMessage::Type() const {
   if (TypeIsSet()) {
-    return m_impl->type.value();
+    return m_impl->type.get();
   }
   static const std::string empty;
   return empty;
@@ -237,7 +237,7 @@ void BasicMessage::TypeClear() { m_impl->type.reset(); }
 
 const std::string& BasicMessage::UserId() const {
   if (UserIdIsSet()) {
-    return m_impl->user_id.value();
+    return m_impl->user_id.get();
   }
   static const std::string empty;
   return empty;
@@ -255,7 +255,7 @@ void BasicMessage::UserIdClear() { m_impl->user_id.reset(); }
 
 const std::string& BasicMessage::AppId() const {
   if (AppIdIsSet()) {
-    return m_impl->app_id.value();
+    return m_impl->app_id.get();
   }
   static const std::string empty;
   return empty;
@@ -271,7 +271,7 @@ void BasicMessage::AppIdClear() { m_impl->app_id.reset(); }
 
 const std::string& BasicMessage::ClusterId() const {
   if (ClusterIdIsSet()) {
-    return m_impl->cluster_id.value();
+    return m_impl->cluster_id.get();
   }
   static const std::string empty;
   return empty;
@@ -291,12 +291,12 @@ Table& BasicMessage::HeaderTable() {
   if (!HeaderTableIsSet()) {
     m_impl->header_table = Table();
   }
-  return m_impl->header_table.value();
+  return m_impl->header_table.get();
 }
 
 const Table& BasicMessage::HeaderTable() const {
   if (HeaderTableIsSet()) {
-    return m_impl->header_table.value();
+    return m_impl->header_table.get();
   }
   static const Table empty;
   return empty;


### PR DESCRIPTION
Since value() does not exists in boost 1.55.
The code around the changes does check that the optionals are initialized.